### PR TITLE
Fix to seqindex.cpp to allow tabs in header line

### DIFF
--- a/src/seqindex.cpp
+++ b/src/seqindex.cpp
@@ -30,6 +30,7 @@ SeqIndex::SeqIndex(const std::string& seqs_filepath)
         /*id_startbyte = byte + 1;*/
         id_endbyte = endbyte;
         id = btllib::split(line, " ")[0].substr(1);
+        id = btllib::split(id, "\t")[0];
       } else if (i % 4 == 1) {
         seq_start = id_endbyte + 1;
         seq_len = endbyte - id_endbyte - 1;


### PR DESCRIPTION
* It was reported in https://github.com/bcgsc/goldrush/issues/138 that goldpolish was throwing an error when inputing reads that had tabs separating the id and other information in the header
* The current code handled spaces after the id, but not tabs
* To fix, do another split of the ID in `seqindex.cpp` by tab characters to account for this
* The test reads file was updated to include reads that space-separated and tab-separated comments in the header line:
```
(btl) [lcoombe@hpce705 test]$ cat test_reads.fq |sed -n '1~4p' |head -n3
@SRR10028109.589610	st:Z:2024-03-14T09:22:04.350+00:00      RG:Z:ccf17720be1a9a9f8f33443ea90c42b6a7685e7f_dna_r10.4.1_e8.2_400bps_hac@v5.0.0
@SRR10028109.366284 st:Z:2024-03-14T09:22:04.350+00:00	RG:Z:ccf17720be1a9a9f8f33443ea90c42b6a7685e7f_dna_r10.4.1_e8.2_400bps_hac@v5.0.0 test
@SRR10028109.540860
```